### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 iree-compiler==20230731.599
-jaxlib==0.4.15.dev20230731
+jaxlib==0.4.15.dev20230801
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -8,8 +8,8 @@
 
 PINNED_VERSIONS = {
   "iree": "cf5d348e78eaa893589d8f8553ddc967e38fa2cf",
-  "xla": "8e26d1b6d895851707e57c4ae87174a76b2c8bab",
-  "jax": "e4955ecd231f84cd33fc51990528235e8ace6a1f"
+  "xla": "538de5f3b0bcb48cbdf35ab1a942f17f62ed0e51",
+  "jax": "2e042b61951e96b34ed01b74b5ff8143c17d6d3d"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: cf5d348e7 Cleanup runtime unused variable settings (#14519) (Sun Jul 30 09:00:14 2023 +0800)
* xla: 538de5f3b Makes `memory_spaces` a pure virtual method in PjRtClient/PjRtDevice (Tue Aug 1 12:32:52 2023 -0700)
* jax: 2e042b619 Enable test for indexing with u8 indices. (Tue Aug 1 12:13:58 2023 -0700)