### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230802.601
-jaxlib==0.4.15.dev20230802
+iree-compiler==20230803.602
+jaxlib==0.4.15.dev20230803
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "b9c06236383871fe413a04ce0b9257798edf0246",
-  "xla": "cd7e46b097433498464b3cf79605c044a4f5e84e",
-  "jax": "a6a8f4850c6dcdb4278422c0e51eddc3d4768970"
+  "iree": "83284b2f1737fa570353636547ca55ee5be1883c",
+  "xla": "8b70c20a838e6c5225618698de352ff14812e835",
+  "jax": "4c3408b704a4f813e794b49835b2e08de733edec"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 83284b2f1 Fix VMVX StrideBufferDescriptor initialization (#14541) (Wed Aug 2 17:22:36 2023 -0700)
* xla: 8b70c20a8 Remove unused variable in gemm_rewriter (Thu Aug 3 12:13:55 2023 -0700)
* jax: 4c3408b70 Add support for custom compilation target devices (Thu Aug 3 12:24:30 2023 -0700)