### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 iree-compiler==20230804.603
-jaxlib==0.4.15.dev20230803
+jaxlib==0.4.15.dev20230805
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -8,8 +8,8 @@
 
 PINNED_VERSIONS = {
   "iree": "c35c88e66f736bbd7da84bf099e17a7bce7de5db",
-  "xla": "af1184ec71f8e3716717b23bcf24c2491da49eda",
-  "jax": "4fb8cdb019bbd2d0761acfeb89b4debd34996696"
+  "xla": "97c308d02d26fafc57f6969040425988462db49c",
+  "jax": "364a245ab2fcc0a7c5187234e94c1a3a8d464c39"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: c35c88e66 Improving consteval support for non-ElementsAttrs attributes. (#14570) (Thu Aug 3 17:39:16 2023 -0700)
* xla: 97c308d02 [cart_legacy] Don't pass an empty device list to GSPMDSharding. (Sat Aug 5 09:35:48 2023 -0700)
* jax: 364a245ab [Memories] Make memory_kind private in C++ and then expose it as a property in python to keep things consistent with other Shardings (Fri Aug 4 18:06:25 2023 -0700)