### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 iree-compiler==20230804.603
-jaxlib==0.4.15.dev20230807
+jaxlib==0.4.15.dev20230808
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -8,8 +8,8 @@
 
 PINNED_VERSIONS = {
   "iree": "c35c88e66f736bbd7da84bf099e17a7bce7de5db",
-  "xla": "90aba7816ac932e965d3b0eabb4102e692dbf71d",
-  "jax": "915241413bf8d65a282894c3693fbcb9d78e9369"
+  "xla": "724fd50f1c0d22c272afa2dc0aadd0e92b309e01",
+  "jax": "6b07f5b32d9c13c392a6a9e47f6ef6125b6238c3"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: c35c88e66 Improving consteval support for non-ElementsAttrs attributes. (#14570) (Thu Aug 3 17:39:16 2023 -0700)
* xla: 724fd50f1 Update TFRT dependency to use revision http://github.com/tensorflow/runtime/commit/e56ba9869cc8ae53578b954a39cbc4796d13bd79. (Tue Aug 8 12:38:00 2023 -0700)
* jax: 6b07f5b32 Use core.valid_jaxtype() in xla.check_arg(). (Tue Aug 8 11:21:09 2023 -0700)