### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230804.603
-jaxlib==0.4.15.dev20230808
+iree-compiler==20230809.608
+jaxlib==0.4.15.dev20230809
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "c35c88e66f736bbd7da84bf099e17a7bce7de5db",
-  "xla": "724fd50f1c0d22c272afa2dc0aadd0e92b309e01",
-  "jax": "6b07f5b32d9c13c392a6a9e47f6ef6125b6238c3"
+  "iree": "d5c928301c138df7f63cadf74dfc83b83b5433a9",
+  "xla": "ed2336c723ac1430e6dabf338ba25f4db4607d0a",
+  "jax": "1e32fd598de9b6d9c0041fb5a4bb037b83840bcf"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: d5c928301 Fix runtime pointer direct cast (#14592) (Mon Aug 7 15:30:40 2023 -0700)
* xla: ed2336c72 [XLA/debuggability] Add options to `SliceModuleAndExtract()` that can remove custom-call to sharding. (Wed Aug 9 12:35:40 2023 -0700)
* jax: 1e32fd598 Merge pull request #17042 from cottrell:me (Wed Aug 9 11:42:57 2023 -0700)