### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230810.609
-jaxlib==0.4.15.dev20230810
+iree-compiler==20230811.610
+jaxlib==0.4.15.dev20230811
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "af3d2a1f9aa2c5572be6b6dfc54a2ae700d948eb",
-  "xla": "e9479de69529b89e79105759176b33d6f70998f8",
-  "jax": "0e80d959c82e769b2e5ccfd91a4018153ba11d90"
+  "iree": "57b9239e0d4988dc440cbe794f689003714e2bda",
+  "xla": "2c5362d15d9a6ca5ab5b5a13ef896e81ab8d3b2a",
+  "jax": "0eb51bec3b677d3a751f813554db3f7668e8565a"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 57b9239e0 Refine release build CMake options. (#14611) (Thu Aug 10 20:13:49 2023 -0700)
* xla: 2c5362d15 [XLA/GPU] Allow ignoring control dependencies during CSE - Add a flag to allow ignoring control deps when replacing one instruction   with another during CSE. - Enable this flag when CSE is exercised after collective schedule linearize   to allow CSE of collectives. (Fri Aug 11 12:16:58 2023 -0700)
* jax: 0eb51bec3 Merge pull request #17080 from jakevdp:tpu-requirements (Fri Aug 11 11:52:32 2023 -0700)