### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230811.610
-jaxlib==0.4.15.dev20230811
+iree-compiler==20230812.611
+jaxlib==0.4.15.dev20230812
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "57b9239e0d4988dc440cbe794f689003714e2bda",
-  "xla": "2c5362d15d9a6ca5ab5b5a13ef896e81ab8d3b2a",
-  "jax": "0eb51bec3b677d3a751f813554db3f7668e8565a"
+  "iree": "50c13ddb4748b40bf2963307447d3124a56860e5",
+  "xla": "b25da487ef32bb3a901aa8eb2899b9e6dc61161f",
+  "jax": "a771ca252513e40949d9433f67bd115a2947f639"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 50c13ddb4 Allow runtime build without tracy tools but with instrumented. (#14649) (Fri Aug 11 22:37:34 2023 -0700)
* xla: b25da487e [xla:gpu2] Add support for mempcy nodes in cuda graphs (Fri Aug 11 21:29:18 2023 -0700)
* jax: a771ca252 Merge pull request #17086 from gnecula:compat_shape (Sat Aug 12 08:32:59 2023 -0700)