### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230813.612
-jaxlib==0.4.15.dev20230813
+iree-compiler==20230814.613
+jaxlib==0.4.15.dev20230814
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "b56ac23bd85f0b9f4a9939c9e87fe83e629f8566",
-  "xla": "b5893d1d77afe553319cbb7831fe990020827c23",
-  "jax": "a771ca252513e40949d9433f67bd115a2947f639"
+  "iree": "4a347236e7a9ab38b4dffe9e089e72e15cf3822c",
+  "xla": "4ed4ae233a904df1d0b085a654ecb162632b401f",
+  "jax": "0d1174a7ca250c82d70a6452feed8538fda8a360"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 4a347236e Fold `linalg.matmul(a, linalg.transpose(b))` into `linalg.matmul_transpose_b(a, b)` (#14645) (Sun Aug 13 17:28:59 2023 -0700)
* xla: 4ed4ae233 Refactor tests under tests/fuzz such that recompilation for each test isn't needed (Mon Aug 14 11:30:58 2023 -0700)
* jax: 0d1174a7c Merge pull request #17103 from jakevdp:fix-numpy-warning (Mon Aug 14 10:41:38 2023 -0700)