### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230814.613
-jaxlib==0.4.15.dev20230814
+iree-compiler==20230815.614
+jaxlib==0.4.15.dev20230815
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "4a347236e7a9ab38b4dffe9e089e72e15cf3822c",
-  "xla": "4ed4ae233a904df1d0b085a654ecb162632b401f",
-  "jax": "0d1174a7ca250c82d70a6452feed8538fda8a360"
+  "iree": "48f7394c6e24171da688095ee3427e0f36f271c8",
+  "xla": "16b24f46ffc68c1c8fa09c98d1e8de827ca6b558",
+  "jax": "a259df0d76e50e0e54fa5a69a7c6b78975cde10a"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 48f7394c6 Segregate the user-API and support in python runtime packages. (#14671) (Mon Aug 14 16:43:41 2023 -0700)
* xla: 16b24f46f Clean up tpu_compile_op targets in tensorflow/core/tpu/kernels (Tue Aug 15 12:29:13 2023 -0700)
* jax: a259df0d7 Move compiler APIs out of dispatch.py and xla_bridge.py into a new jax._src.compiler module. (Tue Aug 15 06:39:46 2023 -0700)