### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230816.615
-jaxlib==0.4.15.dev20230816
+iree-compiler==20230817.616
+jaxlib==0.4.15.dev20230817
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "aef8d3ce065826e915a45e12135d6f791737d8b4",
-  "xla": "baaeccccf8a205ede61be49652237b857907147a",
-  "jax": "4cf85b947db57453c11247c2cf17cf286efebe56"
+  "iree": "3d5a12d429cc4b9a74a32c1db83c4d285e3c5719",
+  "xla": "3e81c1aed423c0465246da1511fa111a0a1d6499",
+  "jax": "2f6dec17762b27ba180f9d776d68c9ebbfcd66ea"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 3d5a12d42 [SPIRV] Do not multibuffer GEMMs with fused leading ops (#14712) (Wed Aug 16 22:39:00 2023 -0700)
* xla: 3e81c1aed allocator_registry: Put a lock around instance_ to avoid races. (Thu Aug 17 12:26:41 2023 -0700)
* jax: 2f6dec177 Merge pull request #17152 from gnecula:tf_dot_general (Thu Aug 17 09:45:22 2023 -0700)