### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 iree-compiler==20230820.619
-jaxlib==0.4.15.dev20230820
+jaxlib==0.4.15.dev20230821
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -8,8 +8,8 @@
 
 PINNED_VERSIONS = {
   "iree": "5bfc37a0170491929c5da8c1fd719a56078da49f",
-  "xla": "51c0ad464e05c18098df7b771a7e02e1ad86dd27",
-  "jax": "b4a628400f59b84a0a0bc47e828b389fc9c34bfd"
+  "xla": "0cd1ee17e85183b60e6680cfb8b32729dee1acc3",
+  "jax": "a14d64b160633db17048eea7732ed21380751389"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 5bfc37a01 [spirv] Drop leading unit dim in f16 fused dequant matvec dispatch  (#14752) (Sat Aug 19 15:03:43 2023 +0000)
* xla: 0cd1ee17e   Allow MSA to reduce size of scoped memory if input/output of the instruction has been assigned in alternative memory. (Mon Aug 21 12:30:22 2023 -0700)
* jax: a14d64b16 Update XLA dependency to use revision http://github.com/openxla/xla/commit/c1e30de7d34a13e6e2c3dcfd4906b4255c98c99e. (Mon Aug 21 06:04:36 2023 -0700)