### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230814.613
-jaxlib==0.4.15.dev20230814
+iree-compiler==20230822.621
+jaxlib==0.4.15.dev20230822
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "4a347236e7a9ab38b4dffe9e089e72e15cf3822c",
-  "xla": "4ed4ae233a904df1d0b085a654ecb162632b401f",
-  "jax": "0d1174a7ca250c82d70a6452feed8538fda8a360"
+  "iree": "2a914c1e7fbfbdecafd506c29ba30df8ea251046",
+  "xla": "1ce6e92be3d3d8fc76629c8d86913d2d13d04671",
+  "jax": "3082109a59725823672fea759c0d374f10f821ea"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 2a914c1e7 [StableHLO] Merge reshape(reshape(x)) (Tue Aug 22 05:32:08 2023 +0000)
* xla: 1ce6e92be Remove deprecated functions with no callers. (Tue Aug 22 10:53:06 2023 -0700)
* jax: 3082109a5 Add a type stub for jax.numpy. (Tue Aug 22 11:50:49 2023 -0700)